### PR TITLE
add relabeled_clone to CTEColumn

### DIFF
--- a/django_cte/meta.py
+++ b/django_cte/meta.py
@@ -19,6 +19,7 @@ class CTEColumn(Expression):
 
     def __init__(self, cte, name, output_field=None):
         self._cte = cte
+        self.table_alias = cte.name
         self.name = self.alias = name
         self._output_field = output_field
 
@@ -59,7 +60,14 @@ class CTEColumn(Expression):
             column = ref.target.column
         else:
             column = self.name
-        return "%s.%s" % (qn(self._cte.name), qn(column)), []
+        return "%s.%s" % (qn(self.table_alias), qn(column)), []
+
+    def relabeled_clone(self, relabels):
+        if self.table_alias is not None and self.table_alias in relabels:
+            clone = self.copy()
+            clone.table_alias = relabels[self.table_alias]
+            return clone
+        return self
 
 
 class CTEColumnRef(Expression):


### PR DESCRIPTION
This is probably the worst way to do it, but it works for me. Because the cte.col.column_name has no reference the the cloned query when it's cloned in resolve_expression, I'm just adding this table alias when it happens. It probably won't work if it's nested more than once.