### PR TITLE
Use the public annotations

### DIFF
--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -105,7 +105,7 @@ class With(object):
         query = CTEQuery(cte_query.model)
         query.join(BaseTable(self.name, None))
         query.default_cols = cte_query.default_cols
-        if cte_query._annotations:
+        if cte_query.annotations:
             for alias, value in cte_query.annotations.items():
                 col = CTEColumnRef(alias, value.output_field)
                 query.add_annotation(col, alias)


### PR DESCRIPTION
The _annotations property was used to avoid creating the OrderedDict when it wasn't necessary. Newer versions of Python don't need to use OrderedDict, so the _annotations property has been removed. Instead, we should just use the public .annotations property, which has been around since Django 1.8. This has the potential to make some things slower on older versions of Python or Django, but for compatibility it seems like the right choice to me.

References #10 . Thanks to @jnns for making it easy to know what the right course of action is here. This is not sufficient for Django 3 compatibility, just a necessary step toward it.