### PR TITLE
Ensure we quote the cte table name if needed

### DIFF
--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -76,8 +76,9 @@ class CTECompiler(object):
         params = []
         for cte in query._with_ctes:
             compiler = cte.query.get_compiler(connection=connection)
+            qn = compiler.quote_name_unless_alias
             cte_sql, cte_params = compiler.as_sql()
-            ctes.append(cls.TEMPLATE.format(name=cte.name, query=cte_sql))
+            ctes.append(cls.TEMPLATE.format(name=qn(cte.name), query=cte_sql))
             params.extend(cte_params)
 
         # Always use WITH RECURSIVE

--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -19,15 +19,17 @@ def raw_cte_sql(sql, params, refs):
             return []
 
     class raw_cte_compiler(object):
-        @staticmethod
-        def as_sql():
+        def as_sql(self, ):
             return sql, params
+
+        def quote_name_unless_alias(self, name):
+            return name
 
     class raw_cte_queryset(object):
         class query(object):
             @staticmethod
             def get_compiler(connection):
-                return raw_cte_compiler
+                return raw_cte_compiler()
 
             @staticmethod
             def resolve_ref(name):

--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -19,17 +19,21 @@ def raw_cte_sql(sql, params, refs):
             return []
 
     class raw_cte_compiler(object):
-        def as_sql(self, ):
+
+        def __init__(self, connection):
+            self.connection = connection
+
+        def as_sql(self):
             return sql, params
 
         def quote_name_unless_alias(self, name):
-            return name
+            return self.connection.ops.quote_name(name)
 
     class raw_cte_queryset(object):
         class query(object):
             @staticmethod
             def get_compiler(connection):
-                return raw_cte_compiler()
+                return raw_cte_compiler(connection)
 
             @staticmethod
             def resolve_ref(name):

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -36,3 +36,28 @@ class TestRawCTE(TestCase):
 
         data = [(r.name, r.parent.name, r.avg_order) for r in moon_avg]
         self.assertEqual(data, [('moon', 'earth', 2)])
+
+    def test_raw_cte_sql_name_escape(self):
+        cte = With(
+            raw_cte_sql(
+                """
+                SELECT region_id, AVG(amount) AS avg_order
+                FROM tests_order
+                WHERE region_id = %s
+                GROUP BY region_id
+                """,
+                ["moon"],
+                {"region_id": text_field, "avg_order": int_field},
+            ),
+            name="mixedCaseCTEName"
+        )
+        moon_avg = (
+            cte
+            .join(Region, name=cte.col.region_id)
+            .annotate(avg_order=cte.col.avg_order)
+            .with_cte(cte)
+        )
+        self.assertTrue(
+            str(moon_avg.query).startswith(
+                'WITH RECURSIVE "mixedCaseCTEName"')
+        )


### PR DESCRIPTION
Postgresql an possibly other dbms requires the CTE name to be quoted unless it is lower case unquoted CTE names are always folded to lower case. This causes CTE that use a camel case name to break if referenced from a subquery or annotation.

This patch ensure we use the django's active compiler to escaping the CTE name.

