### PR TITLE
Fix default CTEManager so it can use from_queryset corectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,38 @@ Orders returned by this query will have a `region_total` attribute containing
 the sum of all order amounts in the order's region.
 
 
+### Simple Common Table Expressions with custom Manager and QuerySets
+
+If you need to use a custom `QuerySets` these should have a base class derived
+from `QTEQuerySet`.
+
+
+class PremiumOrdersQueySet(CTEQuerySet):
+    return self.filter(amount__gt=100)
+
+
+class PremiumOrders(Orders):
+    class Meta:
+        proxy = True
+
+    objects = PremiumOrdersQueySet.as_manager()
+
+
+These can also be use with custom `Manager` or `Manager` and `QuerySet`
+
+class CustomManager(CTEManager):
+    def special_method(self):
+        return
+
+
+class AltOrders(Orders):
+    class Meta:
+        proxy = True
+
+    premium = CustomManager.from_queryset(PremiumOrdersQueySet)()
+    objects = CustomManager()
+
+
 ### Recursive Common Table Expressions
 
 Recursive CTE queries can be constructed using `With.recursive`.

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -142,6 +142,15 @@ class CTEQuerySet(QuerySet):
         qs.query._with_ctes.append(cte)
         return qs
 
+    def as_manager(cls):
+        # Address the circular dependency between
+        # `CTEQuerySet` and `CTEManager`.
+        manager = CTEManager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+    as_manager.queryset_only = True
+    as_manager = classmethod(as_manager)
+
 
 class CTEManager(Manager.from_queryset(CTEQuerySet)):
     """Manager for models that perform CTE queries"""
@@ -149,6 +158,7 @@ class CTEManager(Manager.from_queryset(CTEQuerySet)):
     @classmethod
     def from_queryset(cls, queryset_class, class_name=None):
         if not issubclass(queryset_class, CTEQuerySet):
-            raise TypeError("models with CTE support need to use a CTEQuerySet")
+            raise TypeError(
+                "models with CTE support need to use a CTEQuerySet")
         return super(CTEManager, cls).from_queryset(
             queryset_class, class_name=class_name)

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -121,13 +121,6 @@ class With(object):
         return self.query.resolve_ref(name)
 
 
-class CTEManager(Manager):
-    """Manager for models that perform CTE queries"""
-
-    def get_queryset(self):
-        return CTEQuerySet(self.model, using=self._db)
-
-
 class CTEQuerySet(QuerySet):
     """QuerySet with support for Common Table Expressions"""
 
@@ -148,3 +141,14 @@ class CTEQuerySet(QuerySet):
         qs = self._clone()
         qs.query._with_ctes.append(cte)
         return qs
+
+
+class CTEManager(Manager.from_queryset(CTEQuerySet)):
+    """Manager for models that perform CTE queries"""
+
+    @classmethod
+    def from_queryset(cls, queryset_class, class_name=None):
+        if not issubclass(queryset_class, CTEQuerySet):
+            raise TypeError("models with CTE support need to use a CTEQuerySet")
+        return super(CTEManager, cls).from_queryset(
+            queryset_class, class_name=class_name)

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,7 +10,6 @@ from django.db.models import (
     IntegerField,
     TextField,
 )
-from django.db.models.query import QuerySet
 
 from django_cte import CTEManager, CTEQuerySet
 
@@ -31,14 +30,6 @@ class LT25QuerySet(CTEQuerySet):
 
     def lt25(self):
         return self.filter(amount__lt=25)
-
-
-class LT40Manager(CTEManager):
-    # This is a semi broke manager but allows testing of the documented
-    # use of get_queryset. It is broken by ignoring the queryset passed
-    # to it via the static method from_queryset
-    def get_queryset(self):
-        return LT40QuerySet(model=self.model, using=self._db)
 
 
 class LTManager(CTEManager):
@@ -62,20 +53,6 @@ class OrderFromLT40(Order):
     class Meta:
         proxy = True
     objects = CTEManager.from_queryset(LT40QuerySet)()
-
-
-class OrderCustomLimitedManagerNQuery(Order):
-    """
-    This was the original documented manager setup a custom
-    manager and queryset.
-
-    This is fine if the model isn't going to be in another
-    python module where you have full controll over the managers
-    and querysets.
-    """
-    class Meta:
-        proxy = True
-    objects = LT40Manager.from_queryset(LT40QuerySet)()
 
 
 class OrderCustomManagerNQuery(Order):

--- a/tests/models.py
+++ b/tests/models.py
@@ -55,6 +55,12 @@ class OrderFromLT40(Order):
     objects = CTEManager.from_queryset(LT40QuerySet)()
 
 
+class OrderLT40AsManager(Order):
+    class Meta:
+        proxy = True
+    objects = LT40QuerySet.as_manager()
+
+
 class OrderCustomManagerNQuery(Order):
     class Meta:
         proxy = True

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,6 +10,7 @@ from django.db.models import (
     IntegerField,
     TextField,
 )
+from django.db.models.query import QuerySet
 
 from django_cte import CTEManager, CTEQuerySet
 
@@ -20,10 +21,28 @@ class LT40QuerySet(CTEQuerySet):
         return self.filter(amount__lt=40)
 
 
-class LT40Manager(CTEManager):
+class LT30QuerySet(CTEQuerySet):
 
+    def lt30(self):
+        return self.filter(amount__lt=30)
+
+
+class LT25QuerySet(CTEQuerySet):
+
+    def lt25(self):
+        return self.filter(amount__lt=25)
+
+
+class LT40Manager(CTEManager):
+    # This is a semi broke manager but allows testing of the documented
+    # use of get_queryset. It is broken by ignoring the queryset passed
+    # to it via the static method from_queryset
     def get_queryset(self):
         return LT40QuerySet(model=self.model, using=self._db)
+
+
+class LTManager(CTEManager):
+    pass
 
 
 class Region(Model):
@@ -33,10 +52,42 @@ class Region(Model):
 
 
 class Order(Model):
-    objects = LT40Manager.from_queryset(LT40QuerySet)()
+    objects = CTEManager()
     id = AutoField(primary_key=True)
     region = ForeignKey(Region, on_delete=CASCADE)
     amount = IntegerField(default=0)
+
+
+class OrderFromLT40(Order):
+    class Meta:
+        proxy = True
+    objects = CTEManager.from_queryset(LT40QuerySet)()
+
+
+class OrderCustomLimitedManagerNQuery(Order):
+    """
+    This was the original documented manager setup a custom
+    manager and queryset.
+
+    This is fine if the model isn't going to be in another
+    python module where you have full controll over the managers
+    and querysets.
+    """
+    class Meta:
+        proxy = True
+    objects = LT40Manager.from_queryset(LT40QuerySet)()
+
+
+class OrderCustomManagerNQuery(Order):
+    class Meta:
+        proxy = True
+    objects = LTManager.from_queryset(LT25QuerySet)()
+
+
+class OrderCustomManager(Order):
+    class Meta:
+        proxy = True
+    objects = LTManager()
 
 
 class KeyPair(Model):

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -181,35 +181,6 @@ class TestCTE(TestCase):
             {'region_id': 'mercury', 'region_parent': 'sun'},
         ])
 
-    def test_cte_queryset_with_custom_queryset(self):
-        cte = With(
-            Order.objects
-            .annotate(region_parent=F("region__parent_id"))
-            .filter(region__parent_id="sun")
-        )
-        orders = (
-            cte.queryset()
-            .with_cte(cte)
-            .lt40()  # custom queryset method
-            .order_by("region_id", "amount")
-        )
-        print(orders.query)
-
-        data = [(x.region_id, x.amount, x.region_parent) for x in orders]
-        self.assertEqual(data, [
-            ("earth", 30, "sun"),
-            ("earth", 31, "sun"),
-            ("earth", 32, "sun"),
-            ("earth", 33, "sun"),
-            ('mercury', 10, 'sun'),
-            ('mercury', 11, 'sun'),
-            ('mercury', 12, 'sun'),
-            ('venus', 20, 'sun'),
-            ('venus', 21, 'sun'),
-            ('venus', 22, 'sun'),
-            ('venus', 23, 'sun'),
-        ])
-
     def test_named_simple_ctes(self):
         totals = With(
             Order.objects

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -11,6 +11,7 @@ from django_cte import With, CTEQuerySet, CTEManager
 from .models import (
     Order,
     OrderFromLT40,
+    OrderLT40AsManager,
     OrderCustomManagerNQuery,
     OrderCustomManager,
     LT40QuerySet,
@@ -26,6 +27,9 @@ class TestCTE(TestCase):
 
     def test_cte_queryset_correct_from_queryset(self):
         self.assertEqual(type(OrderFromLT40.objects.all()), LT40QuerySet)
+
+    def test_cte_queryset_correct_queryset_as_manager(self):
+        self.assertEqual(type(OrderLT40AsManager.objects.all()), LT40QuerySet)
 
     def test_cte_queryset_correct_manager_n_from_queryset(self):
         self.assertIsInstance(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from __future__ import print_function
+from django.db.models.expressions import F
+from django.db.models.query import QuerySet
+from django.test import TestCase
+
+from django_cte import With, CTEQuerySet, CTEManager
+
+from .models import (
+    Order,
+    OrderFromLT40,
+    OrderCustomLimitedManagerNQuery,
+    OrderCustomManagerNQuery,
+    OrderCustomManager,
+    LT40QuerySet,
+    LT40Manager,
+    LTManager,
+    LT25QuerySet,
+)
+
+class TestCTE(TestCase):
+    def test_cte_queryset_correct_defaultmanager(self):
+        self.assertEqual(type(Order._default_manager), CTEManager)
+        self.assertEqual(type(Order.objects.all()), CTEQuerySet)
+
+    def test_cte_queryset_correct_from_queryset(self):
+        self.assertEqual(type(OrderFromLT40.objects.all()), LT40QuerySet)
+
+    def test_cte_queryset_correct_manager_n_from_queryset(self):
+        self.assertIsInstance(
+            OrderCustomManagerNQuery._default_manager, LTManager)
+        self.assertEqual(type(
+            OrderCustomManagerNQuery.objects.all()), LT25QuerySet)
+
+    def test_cte_create_manager_from_non_cteQuery(self):
+        class BrokenQuerySet(QuerySet):
+            "This should be a CTEQuerySet if we want this to work"
+
+        with self.assertRaises(TypeError):
+            CTEManager.from_queryset(BrokenQuerySet)()
+
+    def test_cte_queryset_correct_limitedmanager(self):
+        self.assertEqual(type(OrderCustomManager._default_manager), LTManager)
+        # Check the expected even if not ideal behavior occurs
+        self.assertIsInstance(OrderCustomManager.objects.all(), CTEQuerySet)
+
+    def test_cte_queryset_correct_limitedmanager_n_from_queryset(self):
+        self.assertTrue(
+            isinstance(OrderCustomLimitedManagerNQuery._default_manager,
+            LT40Manager))
+        self.assertEqual(
+            type(OrderCustomLimitedManagerNQuery.objects.all()), LT40QuerySet)
+
+    def test_cte_queryset_with_from_queryset(self):
+        self.assertEqual(type(OrderFromLT40.objects.all()), LT40QuerySet)
+
+        cte = With(
+            OrderFromLT40.objects
+            .annotate(region_parent=F("region__parent_id"))
+            .filter(region__parent_id="sun")
+        )
+        orders = (
+            cte.queryset()
+            .with_cte(cte)
+            .lt40()  # custom queryset method
+            .order_by("region_id", "amount")
+        )
+        print(orders.query)
+
+        data = [(x.region_id, x.amount, x.region_parent) for x in orders]
+        self.assertEqual(data, [
+            ("earth", 30, "sun"),
+            ("earth", 31, "sun"),
+            ("earth", 32, "sun"),
+            ("earth", 33, "sun"),
+            ('mercury', 10, 'sun'),
+            ('mercury', 11, 'sun'),
+            ('mercury', 12, 'sun'),
+            ('venus', 20, 'sun'),
+            ('venus', 21, 'sun'),
+            ('venus', 22, 'sun'),
+            ('venus', 23, 'sun'),
+        ])
+
+    def test_cte_queryset_with_custom_queryset(self):
+        cte = With(
+            OrderCustomManagerNQuery.objects
+            .annotate(region_parent=F("region__parent_id"))
+            .filter(region__parent_id="sun")
+        )
+        orders = (
+            cte.queryset()
+            .with_cte(cte)
+            .lt25()  # custom queryset method
+            .order_by("region_id", "amount")
+        )
+        print(orders.query)
+
+        data = [(x.region_id, x.amount, x.region_parent) for x in orders]
+        self.assertEqual(data, [
+            ('mercury', 10, 'sun'),
+            ('mercury', 11, 'sun'),
+            ('mercury', 12, 'sun'),
+            ('venus', 20, 'sun'),
+            ('venus', 21, 'sun'),
+            ('venus', 22, 'sun'),
+            ('venus', 23, 'sun'),
+        ])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -11,14 +11,13 @@ from django_cte import With, CTEQuerySet, CTEManager
 from .models import (
     Order,
     OrderFromLT40,
-    OrderCustomLimitedManagerNQuery,
     OrderCustomManagerNQuery,
     OrderCustomManager,
     LT40QuerySet,
-    LT40Manager,
     LTManager,
     LT25QuerySet,
 )
+
 
 class TestCTE(TestCase):
     def test_cte_queryset_correct_defaultmanager(self):
@@ -45,13 +44,6 @@ class TestCTE(TestCase):
         self.assertEqual(type(OrderCustomManager._default_manager), LTManager)
         # Check the expected even if not ideal behavior occurs
         self.assertIsInstance(OrderCustomManager.objects.all(), CTEQuerySet)
-
-    def test_cte_queryset_correct_limitedmanager_n_from_queryset(self):
-        self.assertTrue(
-            isinstance(OrderCustomLimitedManagerNQuery._default_manager,
-            LT40Manager))
-        self.assertEqual(
-            type(OrderCustomLimitedManagerNQuery.objects.all()), LT40QuerySet)
 
     def test_cte_queryset_with_from_queryset(self):
         self.assertEqual(type(OrderFromLT40.objects.all()), LT40QuerySet)


### PR DESCRIPTION
This commit changes the way that django-cte manager select the queryset to use.

The issues is that the current code forces a new manager to be written for each queryset this is fine if the code is part of an application.  If the code is part of a module then this isn't always controllable.

```
class DataQuerySet(CTEQuerySet):
    def is_default_value(self):
        return self.filter(value = 5)

class DataModel(Model):
    objects = CTEManager.from_queryset(DataQuerySet)()
    value = IntegerField(default=5)

results = DataModel.objects.is_default_value()
```


