### PR TITLE
Added a with_cte default

### DIFF
--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -88,7 +88,7 @@ class With(object):
         parent = query.get_initial_alias()
         query.join(QJoin(parent, self.name, self.name, on_clause, join_type))
 
-        if with_cte == False:
+        if with_cte == False or self.query is None:
             return queryset
         elif with_cte is None:
             return queryset.with_cte(self)
@@ -122,7 +122,7 @@ class With(object):
 
         qs.query = query
 
-        if with_cte == False:
+        if with_cte == False or self.query is None:
             return qs
         elif with_cte is None:
             return qs.with_cte(self)
@@ -154,7 +154,7 @@ class CTEQuerySet(QuerySet):
         """
         qs = self._clone()
 
-        # If this CET was added already, honor this request to add it
+        # If this CTE was added already, honor this request to add it
         # to the end of the list removing a prior entry if it exists.
         if cte in qs.query._with_ctes:
             qs.query._with_ctes.remove(cte)


### PR DESCRIPTION
This saves a lot of redundant syntax in most basic use cases, and obviates the need, in those use cases, for an explicit `.with_cte()` call

So the simple sample in README moves from:

```py
cte = With(
    Order.objects
    .values("region_id")
    .annotate(total=Sum("amount"))
)

orders = (
    cte.join(Order, region=cte.col.region_id)
    .with_cte(cte)
    .annotate(region_total=cte.col.total)
    .order_by("amount")
)
```

to:

```py
cte = With(
    Order.objects
    .values("region_id")
    .annotate(total=Sum("amount"))
)

orders = (
    cte.join(Order, region=cte.col.region_id)
    .annotate(region_total=cte.col.total)
    .order_by("amount")
)
```

A small gain in elegance IMHO, while preserving three key features:

1.  Legacy behaviour is conserved (albeit with an infinitesimal performance hit, adding the CTE, removing it and adding it again for the same end result).
2. The ability to force legacy behaviour without this add/remove/add using `with_cte=False` as an argument to `queryset()` or `join()`
3. The ability to add any old CTE that way, or with subsequent `with_cte()` calls as always, as stated all legacy behaviour is honoured.