### PR TITLE
Fix a compatibility bug

### DIFF
--- a/django_cte/expressions.py
+++ b/django_cte/expressions.py
@@ -41,8 +41,10 @@ class CTESubqueryResolver(object):
         # NOTE this uses the old (pre-Django 3) way of resolving.
         # Should a different technique should be used on Django 3+?
         clone = self.annotation.resolve_expression(*args, **kw)
+        
         if isinstance(self.annotation, Subquery):
-            for cte in get_query(clone)._with_ctes:
+            query = get_query(clone)
+            for cte in getattr(query, "_with_ctes", []):
                 resolve_all(cte.query.where)
                 for key, value in cte.query.annotations.items():
                     if isinstance(value, Subquery):


### PR DESCRIPTION
Found a compatibility bug here. Added this to one of my models:

```
    objects = CTEManager()
```

and then failed local tests. Turns out it was because of a premise at this line that the query has a `_with_ctes` attribute. I traced the code and don't fully understand how and why we land here without one, but it's ultimately because the `clone` is of type `django.db.models.expressions.Subquery` when I land here. And if I permit that (by making this snippet robust against that) then:

1. My tests pass ;-) - they are nowhere near complete mind you, but the basic tests pass fine now)
2. nosetests on django_cte pass.

Conclusion: the premise is not crucial to its working alongside `With()` queries but it seems to break ordinary queries (in legacy code that we're plugging this into) that don't use `With()`. Relaxing the premise seems to break nothing and permit legacy code to run.

It's a tiny little, fairly pythonesque fix which says in a roundabout way "If we land here, and we have no CTEs, then we have no CTEs, all good".

