### PR TITLE
Pin Django to supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     license='BSD License',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    install_requires=['django>=2.2,<4.1'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
In a similar vain as #52. This ensures that django-cte can't be installed together with an unsupported/incompatible version of Django (e.g. Pip will complain during installation).

We had an "issue" with dependabot kept trying to upgrade Django to v4.0.x in one of our projects because it couldn't figure out that django-cte v1.1.5 and Django v4.0.x wasn't compatible. I _think_ this would solve such a scenario.

A downside is increased maintenance burden in that a new release will have to made for every major/minor release of Django to update the supported version range.

Feel free to close if you think this will just be a maintenance headache.