### PR TITLE
Add regression test and fix CTE assumption for subqueries

### DIFF
--- a/django_cte/expressions.py
+++ b/django_cte/expressions.py
@@ -42,7 +42,7 @@ class CTESubqueryResolver(object):
         # Should a different technique should be used on Django 3+?
         clone = self.annotation.resolve_expression(*args, **kw)
         if isinstance(self.annotation, Subquery):
-            for cte in get_query(clone)._with_ctes:
+            for cte in getattr(get_query(clone), '_with_ctes', []):
                 resolve_all(cte.query.where)
                 for key, value in cte.query.annotations.items():
                     if isinstance(value, Subquery):

--- a/tests/models.py
+++ b/tests/models.py
@@ -45,11 +45,20 @@ class Region(Model):
         db_table = "region"
 
 
+class User(Model):
+    id = AutoField(primary_key=True)
+    name = TextField()
+
+    class Meta:
+        db_table = "user"
+
+
 class Order(Model):
     objects = CTEManager()
     id = AutoField(primary_key=True)
     region = ForeignKey(Region, on_delete=CASCADE)
     amount = IntegerField(default=0)
+    user = ForeignKey(User, null=True, on_delete=CASCADE)
 
     class Meta:
         db_table = "orders"


### PR DESCRIPTION
## Summary
Upgrading to `django-cte==1.2.0`, [our project ](https://github.com/learningequality/studio) ran into an error mixing models that use the CTE manager with those that don't use it. I added a test for the issue which produces the following error without the corresponding fix:
```
ERROR: test_non_cte_subquery (tests.test_cte.TestCTE)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bjester/Projects/learningequality/django-cte/tests/test_cte.py", line 448, in test_non_cte_subquery
    Order.objects
  File "/home/bjester/Projects/learningequality/django-cte/venv/lib/python3.8/site-packages/django/db/models/query.py", line 1225, in annotate
    return self._annotate(args, kwargs, select=True)
  File "/home/bjester/Projects/learningequality/django-cte/venv/lib/python3.8/site-packages/django/db/models/query.py", line 1273, in _annotate
    clone.query.add_annotation(
  File "/home/bjester/Projects/learningequality/django-cte/django_cte/query.py", line 49, in add_annotation
    super(CTEQuery, self).add_annotation(annotation, *args, **kw)
  File "/home/bjester/Projects/learningequality/django-cte/venv/lib/python3.8/site-packages/django/db/models/sql/query.py", line 1105, in add_annotation
    annotation = annotation.resolve_expression(
  File "/home/bjester/Projects/learningequality/django-cte/django_cte/expressions.py", line 45, in resolve_expression
    for cte in get_query(clone)._with_ctes:
AttributeError: 'Query' object has no attribute '_with_ctes'
```