### PR TITLE
fix: add EXPLAIN clause in correct position when using .explain() method

### DIFF
--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -103,7 +103,7 @@ class CTECompiler(object):
             sql.extend(["WITH RECURSIVE", ", ".join(ctes)])
         base_sql, base_params = as_sql()
 
-        if explain_query is not None:
+        if explain_query:
             query.explain_query = explain_query
 
         sql.append(base_sql)

--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -86,9 +86,15 @@ class CTECompiler(object):
         if explain_query:
             explain_format = getattr(query, "explain_format", None)
             explain_options = getattr(query, "explain_options", {})
-            sql.append(connection.ops.explain_query_prefix(explain_format, **explain_options))
-            # this needs to get set to False so that the base as_sql() doesn't insert the EXPLAIN statement where it
-            # would end up between the WITH ... clause and the final SELECT
+            sql.append(
+                connection.ops.explain_query_prefix(
+                    explain_format,
+                    **explain_options
+                )
+            )
+            # this needs to get set to False so that the base as_sql() doesn't
+            # insert the EXPLAIN statement where it would end up between the
+            # WITH ... clause and the final SELECT
             query.explain_query = False
 
         if ctes:
@@ -97,7 +103,6 @@ class CTECompiler(object):
             sql.extend(["WITH RECURSIVE", ", ".join(ctes)])
         base_sql, base_params = as_sql()
 
-        # restore the explain_query value
         if explain_query is not None:
             query.explain_query = explain_query
 

--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -81,10 +81,26 @@ class CTECompiler(object):
             ctes.append(cls.TEMPLATE.format(name=qn(cte.name), query=cte_sql))
             params.extend(cte_params)
 
-        # Always use WITH RECURSIVE
-        # https://www.postgresql.org/message-id/13122.1339829536%40sss.pgh.pa.us
-        sql = ["WITH RECURSIVE", ", ".join(ctes)] if ctes else []
+        explain_query = getattr(query, "explain_query", None)
+        sql = []
+        if explain_query:
+            explain_format = getattr(query, "explain_format", None)
+            explain_options = getattr(query, "explain_options", {})
+            sql.append(connection.ops.explain_query_prefix(explain_format, **explain_options))
+            # this needs to get set to False so that the base as_sql() doesn't insert the EXPLAIN statement where it
+            # would end up between the WITH ... clause and the final SELECT
+            query.explain_query = False
+
+        if ctes:
+            # Always use WITH RECURSIVE
+            # https://www.postgresql.org/message-id/13122.1339829536%40sss.pgh.pa.us
+            sql.extend(["WITH RECURSIVE", ", ".join(ctes)])
         base_sql, base_params = as_sql()
+
+        # restore the explain_query value
+        if explain_query is not None:
+            query.explain_query = explain_query
+
         sql.append(base_sql)
         params.extend(base_params)
         return " ".join(sql), tuple(params)

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -494,7 +494,8 @@ class TestCTE(TestCase):
 
     def test_explain(self):
         """
-        Verifies that using .explain() prepends the EXPLAIN clause in the correct position
+        Verifies that using .explain() prepends the EXPLAIN clause in the
+        correct position
         """
 
         totals = With(
@@ -523,8 +524,8 @@ class TestCTE(TestCase):
             .order_by("amount")
         )
 
-        # the test db (sqlite3) doesn't support EXPLAIN, so let's just check to make sure EXPLAIN is at the top
+        # the test db (sqlite3) doesn't support EXPLAIN, so let's just check
+        # to make sure EXPLAIN is at the top
         orders.query.explain_query = True
 
         self.assertTrue(str(orders.query).startswith("EXPLAIN "))
-

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -491,3 +491,40 @@ class TestCTE(TestCase):
             ('sun', 368),
             ('venus', None)
         ])
+
+    def test_explain(self):
+        """
+        Verifies that using .explain() prepends the EXPLAIN clause in the correct position
+        """
+
+        totals = With(
+            Order.objects
+            .filter(region__parent="sun")
+            .values("region_id")
+            .annotate(total=Sum("amount")),
+            name="totals",
+        )
+        region_count = With(
+            Region.objects
+            .filter(parent="sun")
+            .values("parent")
+            .annotate(num=Count("name")),
+            name="region_count",
+        )
+        orders = (
+            region_count.join(
+                totals.join(Order, region=totals.col.region_id),
+                region__parent=region_count.col.parent_id
+            )
+            .with_cte(totals)
+            .with_cte(region_count)
+            .annotate(region_total=totals.col.total)
+            .annotate(region_count=region_count.col.num)
+            .order_by("amount")
+        )
+
+        # the test db (sqlite3) doesn't support EXPLAIN, so let's just check to make sure EXPLAIN is at the top
+        orders.query.explain_query = True
+
+        self.assertTrue(str(orders.query).startswith("EXPLAIN "))
+


### PR DESCRIPTION
Due to the way that the CTE clauses are added to the compiled SQL, `EXPLAIN` queries are not constructed properly - they end up with the `EXPLAIN` clause inserted between the CTE clauses and the final `SELECT`.

Since the `EXPLAIN` is normally added within the base `SQLCompiler.as_sql`, changing the behavior requires a little hacking to ensure the `EXPLAIN` clause doesn't end up in the right place:

- Get the value of `explain_query` from the `query` object - note that it's not supported by all engines, which is why `getattr` is used
- If it is `True`, set it to `False` to prevent `as_sql` from inserting it in the wrong place, then initialize the CTE's sql with value from `connection.ops.explain_query_prefix` (copied from the base implementation)
- Build the rest of the SQL query
- Restore the original `explain_query` value, if it was set

SQLite3 apparently doesn't support EXPLAIN, so for testing I had to just check to make sure that the resulting SQL starts with `EXPLAIN`.