### PR TITLE
MATERIALIZED option support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         - 'Django>=4.0,<4.1'
         experimental: [false]
         include:
-        - python: '3.9'
+        - python: '3.10'
           django: 'https://github.com/django/django/archive/refs/heads/main.zip#egg=Django'
           experimental: true
           # NOTE this job will appear to pass even when it fails because of

--- a/django_cte/__init__.py
+++ b/django_cte/__init__.py
@@ -3,4 +3,4 @@ from __future__ import unicode_literals
 
 from .cte import CTEManager, CTEQuerySet, With  # noqa
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -21,25 +21,28 @@ class With(object):
     entities (tables, views, functions, other CTE(s), etc.) referenced
     in the given query as well any query to which this CTE will
     eventually be added.
+    :param materialized: Optional parameter (default: False) which enforce
+    using of MATERIALIZED statement for supporting databases.
     """
 
-    def __init__(self, queryset, name="cte"):
+    def __init__(self, queryset, name="cte", materialized=False):
         self.query = None if queryset is None else queryset.query
         self.name = name
         self.col = CTEColumns(self)
+        self.materialized = materialized
 
     def __getstate__(self):
-        return (self.query, self.name)
+        return (self.query, self.name, self.materialized)
 
     def __setstate__(self, state):
-        self.query, self.name = state
+        self.query, self.name, self.materialized = state
         self.col = CTEColumns(self)
 
     def __repr__(self):
         return "<With {}>".format(self.name)
 
     @classmethod
-    def recursive(cls, make_cte_queryset, name="cte"):
+    def recursive(cls, make_cte_queryset, name="cte", materialized=False):
         """Recursive Common Table Expression: `WITH RECURSIVE ...`
 
         :param make_cte_queryset: Function taking a single argument (a
@@ -47,9 +50,10 @@ class With(object):
         object. The returned `QuerySet` normally consists of an initial
         statement unioned with a recursive statement.
         :param name: See `name` parameter of `__init__`.
+        :param materialized: See `materialized` parameter of `__init__`.
         :returns: The fully constructed recursive cte object.
         """
-        cte = cls(None, name)
+        cte = cls(None, name, materialized)
         cte.query = make_cte_queryset(cte).query
         return cte
 

--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import warnings
-
 import django
 from django.db import connections
 from django.db.models.sql import DeleteQuery, Query, UpdateQuery
@@ -67,8 +65,6 @@ class CTEQuery(Query):
 
 class CTECompiler(object):
 
-    TEMPLATE = "{name} AS {materialized} ({query})"
-
     @classmethod
     def generate_sql(cls, connection, query, as_sql):
         if query.combinator:
@@ -80,12 +76,8 @@ class CTECompiler(object):
             compiler = cte.query.get_compiler(connection=connection)
             qn = compiler.quote_name_unless_alias
             cte_sql, cte_params = compiler.as_sql()
-            template_params = {
-                'name': qn(cte.name),
-                'materialized': cls.get_materialized_keyword(connection, cte),
-                'query': cte_sql
-            }
-            ctes.append(cls.TEMPLATE.format(**template_params))
+            template = cls.get_cte_query_template(cte)
+            ctes.append(template.format(name=qn(cte.name), query=cte_sql))
             params.extend(cte_params)
 
         explain_query = getattr(query, "explain_query", None)
@@ -118,30 +110,10 @@ class CTECompiler(object):
         return " ".join(sql), tuple(params)
 
     @classmethod
-    def is_materialized_keyword_supported(cls, connection):
-        return any(
-            (
-                (
-                    connection.vendor == 'postgresql'
-                    and connection.pg_version >= 120000
-                ),
-                (
-                    connection.vendor == 'sqlite'
-                ),
-            )
-        )
-
-    @classmethod
-    def get_materialized_keyword(cls, connection, cte):
+    def get_cte_query_template(cls, cte):
         if cte.materialized:
-            if cls.is_materialized_keyword_supported(connection):
-                return 'MATERIALIZED'
-            else:
-                warnings.warn(
-                    'MATERIALIZED statement does not supported by %s. '
-                    'Parameter will be skipped by %s.'
-                    % (connection.vendor, str(cte)))
-        return ''
+            return "{name} AS MATERIALIZED ({query})"
+        return "{name} AS ({query})"
 
 
 class CTEUpdateQuery(UpdateQuery, CTEQuery):

--- a/docs/index.md
+++ b/docs/index.md
@@ -415,6 +415,32 @@ Django automatically converts a `LEFT OUTER JOIN` to an `INNER JOIN` in the
 process of building the query. Be sure to test your queries to ensure they
 produce the desired SQL.
 
+## Materialized CTE
+
+Both PostgreSQL 12+ and sqlite 3.35+ supports `MATERIALIZED` keyword for CTE queries.
+To enforce using of this keyword add `materialized` as a parameter of `With(..., materialized=True)`.
+
+
+```py
+cte = With(
+    Order.objects.values('id'),
+    materialized=True
+)
+```
+
+Which produces this SQL:
+
+```sql
+WITH RECURSIVE "cte" AS MATERIALIZED (
+    SELECT 
+        "orders"."id"
+    FROM "orders"
+)
+...
+```
+
+
+
 
 ## Raw CTE SQL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -415,6 +415,7 @@ Django automatically converts a `LEFT OUTER JOIN` to an `INNER JOIN` in the
 process of building the query. Be sure to test your queries to ensure they
 produce the desired SQL.
 
+
 ## Materialized CTE
 
 Both PostgreSQL 12+ and sqlite 3.35+ supports `MATERIALIZED` keyword for CTE queries.
@@ -438,8 +439,6 @@ WITH RECURSIVE "cte" AS MATERIALIZED (
 )
 ...
 ```
-
-
 
 
 ## Raw CTE SQL

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,7 +7,9 @@ import json
 if "DB_SETTINGS" in os.environ:
     _db_settings = json.loads(os.environ["DB_SETTINGS"])
 else:
-    # sqlite3 by default (must be sqlite3 >= 3.8.3 supporting WITH clause)
+    # sqlite3 by default
+    # must be sqlite3 >= 3.8.3 supporting WITH clause
+    # must be sqlite3 >= 3.35.0 supporting MATERIALIZED option
     _db_settings = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:",

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -310,3 +310,15 @@ class TestRecursiveCTE(TestCase):
             list(c.key for c in children),
             ['level 2', 'level 2']
         )
+
+    def test_materialized(self):
+        # This test covers MATERIALIZED option in SQL query
+        def make_regions_cte(cte):
+            return KeyPair.objects.all()
+        cte = With.recursive(make_regions_cte, materialized=True)
+
+        query = KeyPair.objects.with_cte(cte)
+        print(query.query)
+        self.assertTrue(
+            str(query.query).startswith('WITH RECURSIVE "cte" AS MATERIALIZED')
+        )


### PR DESCRIPTION
Support for MATERIALIZED option for modern versions of PostgreSQL and sqlite.

In some cases this option allows significantly reduce query execution time.  