### PR TITLE
added Query into QUERY_TYPES

### DIFF
--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -125,6 +125,7 @@ class CTEDeleteQuery(DeleteQuery, CTEQuery):
 
 
 QUERY_TYPES = {
+    Query: CTEQuery,
     UpdateQuery: CTEUpdateQuery,
     DeleteQuery: CTEDeleteQuery,
 }

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -346,6 +346,17 @@ class TestCTE(TestCase):
             ('sun', 368),
         })
 
+    def test_update_with_subquery(self):
+        # Test for issue: https://github.com/dimagi/django-cte/issues/9
+        # Issue is not reproduces on sqlite3 use postgres to run.
+        # To reproduce the problem it's required to have some join
+        # in the select-query so the compiler will turn it into a subquery.
+        # To add a join use a filter over field of related model
+        orders = Order.objects.filter(region__parent='sun')
+        orders.update(amount=0)
+        for order in orders:
+            assert order.amount == 0
+
     def test_delete_cte_query(self):
         raise SkipTest(
             "this test will not work until `QuerySet.delete` (Django method) "

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -352,10 +352,15 @@ class TestCTE(TestCase):
         # To reproduce the problem it's required to have some join
         # in the select-query so the compiler will turn it into a subquery.
         # To add a join use a filter over field of related model
-        orders = Order.objects.filter(region__parent='sun')
+        orders = Order.objects.filter(region__parent_id='sun')
         orders.update(amount=0)
-        for order in orders:
-            assert order.amount == 0
+        data = {(order.region_id, order.amount) for order in orders}
+        self.assertEqual(data, {
+            ('mercury', 0),
+            ('venus', 0),
+            ('earth', 0),
+            ('mars', 0),
+        })
 
     def test_delete_cte_query(self):
         raise SkipTest(


### PR DESCRIPTION
Fixing #9 and its duplicate #70.

The problem was with `QUERY_TYPES` that did not contain mapping class for `Query`. 
But that class is used in [SQLUpdateCompiler](https://github.com/django/django/blob/1d9d32389c652edc56ada65116d39789896f4820/django/db/models/sql/compiler.py#L2016).

So when `CTEUpdateQueryCompiler` was about to build copy of `CTEUpdateQuery` as a `Query` the result object was still `CTEUpdateQuery` caused by next line where default class is current. 
```python
klass = QUERY_TYPES.get(klass, self.__class__)
```

Fix has been tested on python3.10 and django==4.2.