### PR TITLE
Use pynose in place of nose

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to use Common Table Expressions with the Django ORM.
 ```
 cd django-cte
 mkvirtualenv cte  # or however you choose to setup your environment
-pip install django nose flake8
+pip install django pynose flake8
 
 nosetests
 flake8 --config=setup.cfg


### PR DESCRIPTION
Nose is broken with Python 3.10 which is now the standard on many Linux boxes.

Nose looks dead. Code not touched since 2016. 49 open PR starting 2012, 400 open issues, ending with announcement of a form pynose, which has the Python 3.10 issue fixed.