### PR TITLE
Add a Django Model MixIn

### DIFF
--- a/django_cte/__init__.py
+++ b/django_cte/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from .cte import CTEManager, CTEQuerySet, With  # noqa
+from .cte import CTEModelMixIn, CTEManager, CTEQuerySet, With  # noqa
 
 __version__ = "1.3.1"

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -166,3 +166,7 @@ class CTEManager(Manager.from_queryset(CTEQuerySet)):
                 "models with CTE support need to use a CTEQuerySet")
         return super(CTEManager, cls).from_queryset(
             queryset_class, class_name=class_name)
+
+class CTEModelMixIn():
+    """Model MixIn to inherit from, that has the Manager installed as 'objects'"""
+    objects = CTEManager()


### PR DESCRIPTION
Replaces this syntax:

```
from django_cte import CTEManager

class Order(Model):
    objects = CTEManager()
```

with this:

```
from django_cte import CTEModelMixIn

class Order(Model, CTEModelMixIn):
```

entirely, optionally (that is the earlier syntax works too). This is simply a more canonical (IMHO) Django way of offering the same service (and has extensibility advantages - as in should the package ever need any more model enhancements, the MixIn is there to take them)