### PR TITLE
Fix dj42 issues 66

### DIFF
--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django.db.models import Manager
-from django.db.models.query import Q, QuerySet, ValuesIterable
+from django.db.models.query import (
+    Q, QuerySet, ValuesIterable)
 from django.db.models.sql.datastructures import BaseTable
 
 from .join import QJoin, INNER
@@ -86,11 +87,13 @@ class With(object):
         q_object = Q(*filter_q, **filter_kw)
         map = query.alias_map
         existing_inner = set(a for a in map if map[a].join_type == INNER)
+
         on_clause, _ = query._add_q(q_object, query.used_aliases)
         query.demote_joins(existing_inner)
 
         parent = query.get_initial_alias()
-        query.join(QJoin(parent, self.name, self.name, on_clause, join_type))
+        query.join(QJoin(parent, self, self.name, on_clause, join_type))
+
         return queryset
 
     def queryset(self):
@@ -107,7 +110,7 @@ class With(object):
         qs = cte_query.model._default_manager.get_queryset()
 
         query = CTEQuery(cte_query.model)
-        query.join(BaseTable(self.name, None))
+        alias = query.join(BaseTable(self.name, None))
         query.default_cols = cte_query.default_cols
         if cte_query.annotations:
             for alias, value in cte_query.annotations.items():

--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -23,7 +23,7 @@ def raw_cte_sql(sql, params, refs):
         def __init__(self, connection):
             self.connection = connection
 
-        def as_sql(self):
+        def as_sql(self, *args, **kwargs):
             return sql, params
 
         def quote_name_unless_alias(self, name):

--- a/tests/test_django_fixes.py
+++ b/tests/test_django_fixes.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import operator
+import django
+from django.db.models.expressions import F, Value
+from django.db.models import IntegerField
+from unittest import skipIf
+from django.test import TestCase
+from .models import Order
+
+
+int_field = IntegerField()
+
+
+class TestDjangoFixesWithCTE(TestCase):
+
+    @skipIf(django.VERSION < (4, 2), "Not fixed in django until 4.2")
+    def test_union_with_values_list_and_order_on_annotation(self):
+        # This is a 99% a clone of same test in DJANGO from #31496
+        # tests/queries/test_qs_combinators.py:
+        #   QuerySetSetOperationTests.test_union_with_values_list_and_order_on_annotation
+        # this is to ensure that our code changes to the handling of columns
+        # names doesn't case a regression on model with a CTEQuery sets
+        qs1 = Order.objects.annotate(
+            annotation=Value(-1),
+            multiplier=F("annotation"),
+        ).filter(amount__gte=36)
+        qs2 = Order.objects.annotate(
+            annotation=Value(2),
+            multiplier=F("annotation"),
+        ).filter(amount__lte=35)
+        uq1 = qs1.union(qs2).order_by(
+                "annotation", "amount").values_list("amount", flat=True)
+        self.assertSequenceEqual(
+            uq1,
+            [40, 41, 42, 1000, 2000, 1, 2, 3, 10, 11, 12,
+             20, 21, 22, 23, 30, 31, 32, 33],
+        )
+        uq2 = (
+            qs1.union(qs2)
+            .order_by(
+                F("annotation") * F("multiplier"),
+                "amount",
+            )
+            .values("amount")
+        )
+        self.assertQuerySetEqual(
+            uq2,
+            [40, 41, 42, 1000, 2000, 1, 2, 3, 10, 11, 12,
+             20, 21, 22, 23, 30, 31, 32, 33],
+            operator.itemgetter("amount"),
+        )
+        print(uq1.query)
+        print(uq2.query)


### PR DESCRIPTION
This add support for Django 4.2 to pass the current test.

In Django 4.2 the SQL of a CTE is build but the columns are automatically asigned an alias this cases the CTE references to fail. This commit attempts to choose beter column aliases so they match the CTE names.
ie Unlike Django using col1, col2 for un-aliased columns we use the same as the field name.

Whist this passes the test it is a invasive set of changes, i did think i'd manages a ultra simple set of changes 

The test added is to ensure we don't break the column renaming fix in django 4.2. As the simple removal with_col_aliases in https://github.com/dimagi/django-cte/issues/66#issuecomment-1659145386 does to make django_cte pass it test

Fixes: #66