### PR TITLE
Fix deferred loading

### DIFF
--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -109,6 +109,7 @@ class With(object):
         query = CTEQuery(cte_query.model)
         query.join(BaseTable(self.name, None))
         query.default_cols = cte_query.default_cols
+        query.deferred_loading = cte_query.deferred_loading
         if cte_query.annotations:
             for alias, value in cte_query.annotations.items():
                 col = CTEColumnRef(alias, self.name, value.output_field)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -104,3 +104,12 @@ class TestCTE(TestCase):
             ('venus', 22, 'sun'),
             ('venus', 23, 'sun'),
         ])
+
+    def test_cte_queryset_with_deferred_loading(self):
+        cte = With(
+            OrderCustomManagerNQuery.objects.order_by("id").only("id")[:1]
+        )
+        orders = cte.queryset().with_cte(cte)
+        print(orders.query)
+
+        self.assertEqual([x.id for x in orders], [1])


### PR DESCRIPTION
django-cte currently does not respect deferred loading (defer/only) specified on With query and causes an error in the case when you try to use something like 

```python
cte = With(Model.objects.only("id"))
queryset = cte.queryset().with_cte(cte)
```

<details>
<summary>Stacktrace</summary>

```
Traceback (most recent call last):
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 329, in execute
    return super().execute(query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: no such column: cte.region_id

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/user/work/django-cte/tests/test_manager.py", line 118, in test_cte_queryset_with_only
    self.assertEqual([x.id for x in orders], [1])
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1562, in execute_sql
    cursor.execute(sql, params)
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/.pyenv/versions/3.11.3/envs/django-cte/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 329, in execute
    return super().execute(query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.OperationalError: no such column: cte.region_id
```
</details>