### PR TITLE
Fix `.explain()` in Django >=4.0

### DIFF
--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -561,8 +561,4 @@ class TestCTE(TestCase):
             .order_by("amount")
         )
 
-        # the test db (sqlite3) doesn't support EXPLAIN, so let's just check
-        # to make sure EXPLAIN is at the top
-        orders.query.explain_query = True
-
-        self.assertTrue(str(orders.query).startswith("EXPLAIN "))
+        self.assertIsInstance(orders.explain(), str)


### PR DESCRIPTION
It looks like there was a change in Django 4.0 that broke the `django-cte` explain functionality.

See:
* https://github.com/django/django/commit/fc91ea1e50e5ef207f0f291b3f6c1942b10db7c7
* https://code.djangoproject.com/ticket/27624#comment:12

This wasn't picked up by the unit tests because we manually set `explain_query = True` (which is now unused) rather than call the `.explain()` queryset method.

This PR adds some logic to retrieve `explain_query` for Django < 4.0, and `explain_info` for Django >= 4.0. It also updates the unit tests to call `.explain()` (which appears to work on `sqlite3` as far as I can tell).

There's probably a cleaner way to do this, so feel free rework if you see fit.