### PR TITLE
Handle empty result sets in CTEs

### DIFF
--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -32,7 +32,7 @@ def raw_cte_sql(sql, params, refs):
     class raw_cte_queryset(object):
         class query(object):
             @staticmethod
-            def get_compiler(connection, *args, **kwargs):
+            def get_compiler(connection, *, elide_empty=None):
                 return raw_cte_compiler(connection)
 
             @staticmethod

--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -32,7 +32,7 @@ def raw_cte_sql(sql, params, refs):
     class raw_cte_queryset(object):
         class query(object):
             @staticmethod
-            def get_compiler(connection):
+            def get_compiler(connection, *args, **kwargs):
                 return raw_cte_compiler(connection)
 
             @staticmethod

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -583,3 +583,20 @@ class TestCTE(TestCase):
         )
 
         self.assertEqual(len(orders), 0)
+
+    def test_left_outer_join_on_empty_result_set_cte(self):
+        totals = With(
+            Order.objects
+            .filter(id__in=[])
+            .values("region_id")
+            .annotate(total=Sum("amount")),
+            name="totals",
+        )
+        orders = (
+            totals.join(Order, region=totals.col.region_id, _join_type=LOUTER)
+            .with_cte(totals)
+            .annotate(region_total=totals.col.total)
+            .order_by("amount")
+        )
+
+        self.assertEqual(len(orders), 22)


### PR DESCRIPTION
If Django finds a CTE during SQL generation that will result in empty results, it will throw an EmptyResultSet immediately. Because the CTEs are compiled to SQL prior to the base query in the CTEQueryCompiler, though, the base compiler is missing core information Django needs to gracefully handle this situation, like `col_count` and `klass_info`.

To resolve this, in the case of EmptyResultSet being thrown by CTE compilation, the base `as_sql` will be called as well before reraising.

The creation of the base queryset can not be move before the explain behaviors in `generate_sql` or the generated `EXPLAIN` will throw an error, so the try/except pattern is used instead.

Resolves #84 

I think this will also work for #64 as well, but I couldn't figure out a way to throw that particular error.