### PR TITLE
Unions of recursive cte queries - regression with merger of pull request #99

### DIFF
--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -597,6 +597,25 @@ class TestCTE(TestCase):
 
         self.assertEqual(len(orders), 22)
 
+    def test_union_query_with_no_ctes(self):
+        query_partA = Order.objects.filter(region__name="earth")
+        query_partB = Order.objects.filter(region__name="mars")
+        query_combined = (
+            query_partA.union(query_partB)
+            .order_by('region__name', 'amount')
+            .values_list('region__name', 'amount')
+        )
+        print(query_combined.query)
+        self.assertEqual(list(query_combined), [
+            ('earth', 30),
+            ('earth', 31),
+            ('earth', 32),
+            ('earth', 33),
+            ('mars', 40),
+            ('mars', 41),
+            ('mars', 42),
+        ])
+
     def test_union_query_with_cte(self):
         orders = (
             Order.objects


### PR DESCRIPTION
Hi @millerdev,

Two new test case for union of cte queries.
The main one is testcase `test_recursive_union_query_with_cte` which show the regression caused with the merger of pull request #99 as per the comments by @rgammans the second to ensure we don't break normal unions with CTE models

Unfortunately, this testcase is not the most optimal CTE but shows the issue without adding any new test models.
If pull #99 is reverted this test case then passes, with #99 it cases this testcase to fail raising a OperationalError from the DB driver

