### PR TITLE
Support Django 5.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,11 @@ jobs:
         - 'Django>=4.2,<4.3'
         - 'Django>=5.0,<5.1'
         - 'Django>=5.1,<5.2'
+        - 'Django>=5.2,<5.3'
         exclude:
         - {python: '3.9', django: 'Django>=5.0,<5.1'}
         - {python: '3.9', django: 'Django>=5.1,<5.2'}
+        - {python: '3.9', django: 'Django>=5.2,<5.3'}
     services:
       postgres:
         image: postgres:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     'Framework :: Django :: 5',
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 dependencies = ["django"]

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -203,7 +203,7 @@ class TestCTE(TestCase):
         region_count = With(
             Region.objects
             .filter(parent="sun")
-            .values("parent")
+            .values("parent_id")
             .annotate(num=Count("name")),
             name="region_count",
         )
@@ -541,7 +541,7 @@ class TestCTE(TestCase):
         region_count = With(
             Region.objects
             .filter(parent="sun")
-            .values("parent")
+            .values("parent_id")
             .annotate(num=Count("name")),
             name="region_count",
         )
@@ -626,4 +626,16 @@ class TestCTE(TestCase):
             ('mars', 40),
             ('mars', 41),
             ('mars', 42),
+        ])
+
+    def test_cte_select_pk(self):
+        orders = Order.objects.filter(region="earth").values("pk")
+        cte = With(orders)
+        queryset = cte.join(orders, pk=cte.col.pk).with_cte(cte).order_by("pk")
+        print(queryset.query)
+        self.assertEqual(list(queryset), [
+            {'pk': 9},
+            {'pk': 10},
+            {'pk': 11},
+            {'pk': 12},
         ])

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -83,4 +83,5 @@ class WindowFunctions(TestCase):
                     "column references"
                 )
             raise
-        assert 0, "unexpected pass"
+        if django.VERSION < (5, 2):
+            assert 0, "unexpected pass"


### PR DESCRIPTION
Hello,
A suggestion for how to support Django 5.2.
* `set_values()` before `add_annotation()` since annotations now populate `selected` field.
* Reference implicitly annotated field before trying to resolve reference the normal way.

I modified 2 tests to explicitly select foreign key ID. In Django 5.2 foreign key ID's would be annotated to the foreign key name. Let me know if it is preferred to join on the foreign key name instead.

`test_heterogeneous_filter_in_cte` now works.
