### PR TITLE
Django 5.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         | jq --slurp .
         | tr '\n' ' '
         )" >> $GITHUB_OUTPUT
-    - name: Read Djagno versions from pyproject.toml
+    - name: Read Django versions from pyproject.toml
       id: read-django-versions
       # django_versions=[ "Django~=4.2.0", "Django~=5.1.0", "Django~=5.2.0" ]
       run: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,12 @@ jobs:
       matrix:
         python: ${{ fromJSON(needs.configure.outputs.python_versions) }}
         django:
-        - 'Django>=4.2,<4.3'
-        - 'Django>=5.0,<5.1'
-        - 'Django>=5.1,<5.2'
+        - 'Django~=4.2.0'
+        - 'Django~=5.1.0'
+        - 'Django~=5.2.0'
         exclude:
-        - {python: '3.9', django: 'Django>=5.0,<5.1'}
-        - {python: '3.9', django: 'Django>=5.1,<5.2'}
+        - {python: '3.9', django: 'Django~=5.1.0'}
+        - {python: '3.9', django: 'Django~=5.2.0'}
     services:
       postgres:
         image: postgres:latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Read Python versions from pyproject.toml
-      id: read-versions
+      id: read-python-versions
       # produces output like: python_versions=[ "3.9", "3.10", "3.11", "3.12" ]
       run: >-
         echo "python_versions=$(
@@ -21,8 +21,20 @@ jobs:
         | jq --slurp .
         | tr '\n' ' '
         )" >> $GITHUB_OUTPUT
+    - name: Read Djagno versions from pyproject.toml
+      id: read-django-versions
+      # django_versions=[ "Django~=4.2.0", "Django~=5.1.0", "Django~=5.2.0" ]
+      run: >-
+        echo "django_versions=$(
+        grep -oP '(?<=Framework :: Django :: )\d+\.\d+' pyproject.toml
+        | sed -E 's/(.+)/Django~=\1.0/'
+        | jq --raw-input .
+        | jq --slurp .
+        | tr '\n' ' '
+        )" >> $GITHUB_OUTPUT
     outputs:
-      python_versions: ${{ steps.read-versions.outputs.python_versions }}
+      python_versions: ${{ steps.read-python-versions.outputs.python_versions }}
+      django_versions: ${{ steps.read-django-versions.outputs.django_versions }}
 
   tests:
     needs: [configure]
@@ -31,10 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ${{ fromJSON(needs.configure.outputs.python_versions) }}
-        django:
-        - 'Django~=4.2.0'
-        - 'Django~=5.1.0'
-        - 'Django~=5.2.0'
+        django: ${{ fromJSON(needs.configure.outputs.django_versions) }}
         exclude:
         - {python: '3.9', django: 'Django~=5.1.0'}
         - {python: '3.9', django: 'Django~=5.2.0'}

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -1,4 +1,5 @@
 from django.db.models import Manager
+from django.db.models.expressions import Ref
 from django.db.models.query import Q, QuerySet, ValuesIterable
 from django.db.models.sql.datastructures import BaseTable
 
@@ -125,6 +126,9 @@ class With(object):
         return qs
 
     def _resolve_ref(self, name):
+        selected = getattr(self.query, "selected", None)
+        if selected and name in selected and name not in self.query.annotations:
+            return Ref(name, self.query)
         return self.query.resolve_ref(name)
 
 

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -107,13 +107,13 @@ class With(object):
         query.join(BaseTable(self.name, None))
         query.default_cols = cte_query.default_cols
         query.deferred_loading = cte_query.deferred_loading
+        if cte_query.values_select:
+            query.set_values(cte_query.values_select)
+            qs._iterable_class = ValuesIterable
         if cte_query.annotations:
             for alias, value in cte_query.annotations.items():
                 col = CTEColumnRef(alias, self.name, value.output_field)
                 query.add_annotation(col, alias)
-        if cte_query.values_select:
-            query.set_values(cte_query.values_select)
-            qs._iterable_class = ValuesIterable
         query.annotation_select_mask = cte_query.annotation_select_mask
 
         qs.query = query

--- a/django_cte/cte.py
+++ b/django_cte/cte.py
@@ -110,6 +110,11 @@ class With(object):
         if cte_query.values_select:
             query.set_values(cte_query.values_select)
             qs._iterable_class = ValuesIterable
+        for alias in getattr(cte_query, "selected", None) or ():
+            if alias not in cte_query.annotations:
+                field = cte_query.resolve_ref(alias).output_field
+                col = CTEColumnRef(alias, self.name, field)
+                query.add_annotation(col, alias)
         if cte_query.annotations:
             for alias, value in cte_query.annotations.items():
                 col = CTEColumnRef(alias, self.name, value.output_field)

--- a/django_cte/expressions.py
+++ b/django_cte/expressions.py
@@ -1,4 +1,3 @@
-import django
 from django.db.models import Subquery
 
 
@@ -31,12 +30,8 @@ class CTESubqueryResolver(object):
 
         # --- end copied code --- #
 
-        if django.VERSION < (3, 0):
-            def get_query(clone):
-                return clone.queryset.query
-        else:
-            def get_query(clone):
-                return clone.query
+        def get_query(clone):
+            return clone.query
 
         # NOTE this uses the old (pre-Django 3) way of resolving.
         # Should a different technique should be used on Django 3+?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ license = {file = "LICENSE"}
 readme = {file = "README.md", content-type = "text/markdown"}
 dynamic = ["version"]
 requires-python = ">= 3.9"
+# Python and Django versions are read from this file by GitHub Actions.
+# Precise formatting is important.
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     'Environment :: Web Environment',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,13 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Framework :: Django',
     'Framework :: Django :: 4',
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5',
-    'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
+    'Framework :: Django :: 5.2',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 dependencies = ["django"]

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -203,7 +203,7 @@ class TestCTE(TestCase):
         region_count = With(
             Region.objects
             .filter(parent="sun")
-            .values("parent")
+            .values("parent_id")
             .annotate(num=Count("name")),
             name="region_count",
         )
@@ -541,7 +541,7 @@ class TestCTE(TestCase):
         region_count = With(
             Region.objects
             .filter(parent="sun")
-            .values("parent")
+            .values("parent_id")
             .annotate(num=Count("name")),
             name="region_count",
         )
@@ -556,6 +556,7 @@ class TestCTE(TestCase):
             .annotate(region_count=region_count.col.num)
             .order_by("amount")
         )
+        print(orders.query)
 
         self.assertIsInstance(orders.explain(), str)
 

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -628,3 +628,15 @@ class TestCTE(TestCase):
             ('mars', 41),
             ('mars', 42),
         ])
+
+    def test_cte_select_pk(self):
+        orders = Order.objects.filter(region="earth").values("pk")
+        cte = With(orders)
+        queryset = cte.join(orders, pk=cte.col.pk).with_cte(cte).order_by("pk")
+        print(queryset.query)
+        self.assertEqual(list(queryset), [
+            {'pk': 9},
+            {'pk': 10},
+            {'pk': 11},
+            {'pk': 12},
+        ])

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -75,7 +75,7 @@ class WindowFunctions(TestCase):
         #   SELECT "orders"."region_id" AS "col1", ...
         # "region" INNER JOIN "cte" ON "region"."name" = ("cte"."region_id")
         try:
-            self.assertSequenceEqual({r.name for r in qs}, {"moon", "sun"})
+            self.assertEqual({r.name for r in qs}, {"moon", "sun"})
         except (OperationalError, ProgrammingError) as err:
             if "cte.region_id" in str(err):
                 raise SkipTest(
@@ -83,4 +83,5 @@ class WindowFunctions(TestCase):
                     "column references"
                 )
             raise
-        assert 0, "unexpected pass"
+        if django.VERSION < (5, 2):
+            assert 0, "unexpected pass"


### PR DESCRIPTION
- BREAKING: On Django 5.2 and later, the name specified in `.values('fk_name')` must match the name of the same column referenced by `cte.col.fk_name`, in a join condition, for example. It may end with `_id` or not, but the references must be consistent. This change may require previously working CTE queries to be adjusted when migrating to Django 5.2 ([example](https://github.com/dimagi/django-cte/commit/321d92cd8d1edd515c1f5000a3b12c35265aa4f8)).
- All tests pass on Django 5.2.
- Remove code that was only used for old/unsupported Django versions.
- Update the test matrix, adding Python 3.14 and Django 5.2 and dropping EOL Django 5.0.
- _pyproject.toml_ is the single source of truth for supported Python and Django versions.

Review by commit.

Replaces  #108 