### PR TITLE
Fix raw_cte_queryset in Subqueries

### DIFF
--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -35,4 +35,8 @@ def raw_cte_sql(sql, params, refs):
             def resolve_ref(name):
                 return raw_cte_ref(refs[name])
 
+            @classmethod
+            def resolve_expression(cls, *args, **kwargs):
+                return cls
+
     return raw_cte_queryset

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -52,3 +52,16 @@ class TestRawCTE(TestCase):
             str(moon_avg.query).startswith(
                 'WITH RECURSIVE "mixedCaseCTEName"')
         )
+
+    def test_raw_cte_subquery(self):
+        cte = CTE(raw_cte_sql(
+            "SELECT name as region_name FROM region WHERE name = %s",
+            ["earth"],
+            {"region_name": text_field}
+        ))
+        cte_qs = with_cte(
+            cte, 
+            select=cte.join(Region, name=cte.col.region_name)
+        )
+        regions = Region.objects.filter(name__in=cte_qs)
+        self.assertEqual(list(regions.values_list('name', flat=True)), ['earth'])


### PR DESCRIPTION
When a CTE is created with raw_cte_sql the query object, raw_cte_queryset.query, does not implement resolve_expression, causing an AttributeError. Specifically, this occurs when we use it within a Subquery. This patch adds resolve_expression implementation to raw_cte_queryset.query that simply returns cls. This satisfies django ORM because of duck typing and since the query is raw SQL, no actual expression resolution is needed.