### PR TITLE
Support to perform query that includes `select_for_update()` and `select_related()`

### DIFF
--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -1,5 +1,6 @@
 import pytest
 import django
+from django.db import connections
 from django.db.models import IntegerField, TextField
 from django.db.models.aggregates import Count, Max, Min, Sum
 from django.db.models.expressions import (
@@ -8,6 +9,7 @@ from django.db.models.expressions import (
 from django.db.models.sql.constants import LOUTER
 from django.db.utils import OperationalError, ProgrammingError
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from django_cte import CTE, with_cte
 
@@ -874,3 +876,23 @@ class TestCTE(TestCase):
             {'name': 'sun', 'total': None},
             {'name': 'venus', 'total': None}
         ])
+
+    def test_select_for_update_with_select_related(self):
+        # Test that we lock the order, and only the order, whilst joining to the user table so we
+        # only perform a single query even when accessing the related user with `order.user`.
+        cte = CTE(Order.objects.select_for_update(no_key=True).filter(id=1), name='c')
+        qs = with_cte(cte, select=cte).select_related('user')
+
+        with CaptureQueriesContext(connections['default']) as queries:
+            order = qs.get()
+            _ = order.user
+
+        [query] = queries.captured_queries
+        assert query['sql'] == (
+            # Obtain the lock on the results of the CTE, which should only fetch the 'order'.
+            'WITH RECURSIVE "c" AS (SELECT "orders"."id", "orders"."region_id", "orders"."amount", "orders"."user_id" FROM "orders" WHERE "orders"."id" = 1 FOR NO KEY UPDATE) '
+            # Select the 'order' from the CTE and join to the 'user' table.
+            'SELECT "c"."id", "c"."region_id", "c"."amount", "c"."user_id", "user"."id", "user"."name" FROM "c" '
+            'LEFT OUTER JOIN "user" ON ("c"."user_id" = "user"."id") '
+            'LIMIT 21'
+        )


### PR DESCRIPTION
After reading this [Row Locks With Joins Can Produce Surprising Results in PostgreSQL](https://hakibenita.com/postgres-row-lock-with-join) blog post I was curious as to whether I could reproduce [this query](https://hakibenita.com/postgres-row-lock-with-join#use-a-sub-query:~:text=db%3D*%23%20EXPLAIN-,WITH%20c%20AS%20(%0A%20%20%20%20SELECT%20*%20FROM%20car%20WHERE%20id%20%3D%201%0A%20%20%20%20FOR%20NO%20KEY%20UPDATE%0A)%0ASELECT%20*%20FROM%20c%0AJOIN%20owner%20ON%20c.owner_id%20%3D%20owner.id%3B,-QUERY%20PLAN%0A%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80) using `django-cte`.

```sql
WITH c AS (
    SELECT * FROM car WHERE id = 1
    FOR NO KEY UPDATE
)
SELECT * FROM c
JOIN owner ON c.owner_id = owner.id;
```

Please see the test in this PR, however unfortunately it results in the following error.

```text
TypeError: Cannot call select_related() after .values() or .values_list()
```

I can make the test pass by removing this `qs._fields = ()` [line from here](https://github.com/jamesbeith/django-cte/blob/7c6dc8fb4e67cbe7424a0b2f34a4281ab1d76869/django_cte/cte.py#L143) but that unfortunately causes the `test_django52_annotate_model_field_name_after_queryset` [test](https://github.com/jamesbeith/django-cte/blob/9625fd99beaa8d1a9bad1a62c7ccd84be933882e/tests/test_cte.py#L736) to fail with.

```text
ValueError: The annotation 'id' conflicts with a field on the model.
```

Is there another way to get the same query I'm after using `django-cte`?