### PR TITLE
Django 6.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,9 @@ jobs:
         - {python: '3.9', django: 'Django~=6.0.0'}
         - {python: '3.10', django: 'Django~=6.0.0'}
         - {python: '3.11', django: 'Django~=6.0.0'}
+        - {python: '3.9', django: 'Django~=6.1.0'}
+        - {python: '3.10', django: 'Django~=6.1.0'}
+        - {python: '3.11', django: 'Django~=6.1.0'}
     env:
       allowed_python_failure: '3.14'
     services:

--- a/django_cte/_quoting.py
+++ b/django_cte/_quoting.py
@@ -1,0 +1,14 @@
+import django
+
+# `SQLCompiler.quote_name()` was added in Django 6.1, deprecating
+# `quote_name_unless_alias()`, which did not quote table aliases. Use
+# whichever one Django itself uses so generated SQL agrees on how aliases
+# are spelled. Can be removed when the oldest supported Django is 6.1.
+_QUOTE_NAME = (
+    "quote_name" if django.VERSION >= (6, 1) else "quote_name_unless_alias"
+)
+
+
+def quote_name(compiler):
+    """Get the compiler's name quoting function"""
+    return getattr(compiler, _QUOTE_NAME)

--- a/django_cte/join.py
+++ b/django_cte/join.py
@@ -48,11 +48,13 @@ class QJoin:
     def as_sql(self, compiler, connection):
         """Generate join clause SQL"""
         on_clause_sql, params = self.on_clause.as_sql(compiler, connection)
+        qn = quote_name(compiler)
         if self.table_alias == self.table_name:
             alias = ''
         else:
-            alias = ' %s' % self.table_alias
-        qn = quote_name(compiler)
+            # Quote the alias like the column references pointing at it,
+            # otherwise the database case-folds one but not the other.
+            alias = ' %s' % qn(self.table_alias)
         sql = '%s %s%s ON %s' % (
             self.join_type,
             qn(self.table_name),

--- a/django_cte/join.py
+++ b/django_cte/join.py
@@ -1,5 +1,7 @@
 from django.db.models.sql.constants import INNER
 
+from ._quoting import quote_name
+
 
 class QJoin:
     """Join clause with join condition from Q object clause
@@ -50,7 +52,7 @@ class QJoin:
             alias = ''
         else:
             alias = ' %s' % self.table_alias
-        qn = compiler.quote_name_unless_alias
+        qn = quote_name(compiler)
         sql = '%s %s%s ON %s' % (
             self.join_type,
             qn(self.table_name),

--- a/django_cte/meta.py
+++ b/django_cte/meta.py
@@ -2,6 +2,8 @@ import weakref
 
 from django.db.models.expressions import Col, Expression
 
+from ._quoting import quote_name
+
 try:
     from django.db.models.expressions import ColPairs as _ColPairs
 except ImportError:
@@ -64,7 +66,7 @@ class CTEColumn(Expression):
         return self._ref.output_field
 
     def as_sql(self, compiler, connection):
-        qn = compiler.quote_name_unless_alias
+        qn = quote_name(compiler)
         ref = self._ref
         column = ref.target.column if isinstance(ref, Col) else self.name
         return "%s.%s" % (qn(self.table_alias), qn(column)), []
@@ -111,7 +113,7 @@ class CTEColumnRef(Expression):
         return clone
 
     def as_sql(self, compiler, connection):
-        qn = compiler.quote_name_unless_alias
+        qn = quote_name(compiler)
         table = self._alias or compiler.query.table_map.get(
             self.cte_name, [self.cte_name])[0]
         return "%s.%s" % (qn(table), qn(self.name)), []

--- a/django_cte/query.py
+++ b/django_cte/query.py
@@ -4,6 +4,7 @@ from django.db.models.sql.constants import LOUTER
 
 from .jitmixin import JITMixin, jit_mixin
 from .join import QJoin
+from ._quoting import quote_name
 
 # NOTE: it is currently not possible to execute delete queries that
 # reference CTEs without patching `QuerySet.delete` (Django method)
@@ -83,7 +84,7 @@ def generate_cte_sql(connection, query, as_sql):
             connection=connection, elide_empty=should_elide_empty
         )
 
-        qn = compiler.quote_name_unless_alias
+        qn = quote_name(compiler)
         try:
             cte_sql, cte_params = compiler.as_sql()
         except EmptyResultSet:

--- a/django_cte/raw.py
+++ b/django_cte/raw.py
@@ -22,8 +22,11 @@ def raw_cte_sql(sql, params, refs):
         def as_sql(self):
             return sql, params
 
-        def quote_name_unless_alias(self, name):
+        def quote_name(self, name):
             return self.connection.ops.quote_name(name)
+
+        # Name used by Django < 6.1.
+        quote_name_unless_alias = quote_name
 
     class raw_cte_queryset:
         class query:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Framework :: Django :: 5.1',
     'Framework :: Django :: 5.2',
     'Framework :: Django :: 6.0',
+    'Framework :: Django :: 6.1',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 dependencies = ["django"]
@@ -60,7 +61,7 @@ env_list = [
     {product = [{prefix = "py3", start = 10, stop = 12}, ["django50"]]},
     {product = [{prefix = "py3", start = 10, stop = 13}, ["django51"]]},
     {product = [{prefix = "py3", start = 10, stop = 14}, ["django52"]]},
-    {product = [{prefix = "py3", start = 12, stop = 14}, ["django60", "djangomain"]]},
+    {product = [{prefix = "py3", start = 12, stop = 14}, ["django60", "django61", "djangomain"]]},
 ]
 
 [tool.tox.env_run_base]
@@ -73,5 +74,6 @@ deps = [
   {replace = "if", condition = "factor.django51", then = ["Django>=5.1,<5.2"], extend = true},
   {replace = "if", condition = "factor.django52", then = ["Django>=5.2,<6.0"], extend = true},
   {replace = "if", condition = "factor.django60", then = ["Django>=6.0,<6.1"], extend = true},
+  {replace = "if", condition = "factor.django61", then = ["Django>=6.1,<6.2"], extend = true},
   {replace = "if", condition = "factor.djangomain", then = ["https://github.com/django/django/archive/main.tar.gz"], extend = true},
 ]

--- a/tests/test_cte.py
+++ b/tests/test_cte.py
@@ -881,6 +881,30 @@ class TestCTE(TestCase):
             {'name': 'venus', 'total': None}
         ])
 
+    def test_cte_join_alias_is_quoted(self):
+        # A CTE-joined queryset used as a subquery gets its alias prefix
+        # bumped, so the join alias differs from the CTE name and must be
+        # quoted like the column references pointing at it.
+        totals = CTE(
+            Order.objects
+            .values("region_id")
+            .annotate(total=Sum("amount"))
+        )
+        big_orders = with_cte(
+            totals,
+            select=totals.join(Order, region=totals.col.region_id),
+        ).annotate(region_total=totals.col.total).filter(
+            region_id=OuterRef("name"),
+            region_total__gt=100,
+        )
+        regions = Region.objects.filter(Exists(big_orders)).order_by("name")
+        self.assertEqual([r.name for r in regions], [
+            'earth',
+            'mars',
+            'proxima centauri',
+            'sun',
+        ])
+
     def test_fields_with_db_column(self):
         cte = CTE.recursive(
             lambda cte: WithDBColumn.objects.filter(id=10)


### PR DESCRIPTION
Django 6.1 ([ticket #36795](https://code.djangoproject.com/ticket/36795)) made `SQLCompiler.quote_name()` quote table aliases and deprecated `quote_name_unless_alias()`, which did not. `QJoin.as_sql()` never quoted its alias, so a CTE joined inside a subquery, where the alias is prefix-bumped and no longer matches the CTE name, mixed a bare alias with quoted references to it: `JOIN "cte" U2 ON "U2"."id" = ...`. PostgreSQL case-folds the former but not the latter, raising `missing FROM-clause entry for table "U2"`.

This fixes `test_raw_cte_subquery` and `test_alias_as_subquery` (v1 and current), which already fail on Django 6.1, and adds a test for the join alias. Generated SQL is unchanged on Django < 6.1, where the alias stays bare to match what Django itself emits.

The test matrix is derived from the `Framework :: Django` classifiers, so 6.1 was never exercised. Added it there and as a tox factor.
